### PR TITLE
Allow for suffix-less file paths to return html content

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stasis "2.2.2"
+(defproject stasis "2.2.2-bcg"
   :description "A library of tools for creating static websites."
   :url "http://github.com/magnars/stasis"
   :license {:name "Eclipse Public License"

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -16,9 +16,12 @@
      (.endsWith decoded-uri "/") (str decoded-uri "index.html")
      :else decoded-uri)))
 
-(defn- statically-servable-uri? [^String uri]
-  (or (.endsWith uri "/")
-      (not (re-find #"/[^./]+$" uri))))
+(defn file-without-suffix? [uri]
+  (nil? (re-find #"\.\w+$" uri)))
+
+(defn statically-servable-uri? [^String uri]
+  "All paths are statically servable. / /test /test/ & /test.html."
+  true)
 
 (defn- normalize-page-uris [pages]
   (zipmap (map normalize-uri (keys pages))
@@ -48,7 +51,7 @@
 (defn- serve-page [page uri]
   (-> {:status 200
        :body (if (map? page) (:contents page) page)}
-      (assoc-if (.endsWith uri ".html") :headers {"Content-Type" "text/html"})))
+      (assoc-if (or (file-without-suffix? uri) (.endsWith uri ".html")) :headers {"Content-Type" "text/html"})))
 
 (def not-found
   {:status 404

--- a/test/stasis/core_test.clj
+++ b/test/stasis/core_test.clj
@@ -7,6 +7,11 @@
 (defn noop [_] nil)
 
 (fact
+  "Determine if a path has a suffix."
+  (file-without-suffix? "http://test.com/test") => true
+  (file-without-suffix? "http://test.com/test.html") => false)
+
+(fact
  "Stasis creates a Ring handler to serve your pages."
 
  (let [app (serve-pages {"/page.html" "The page contents"})]
@@ -38,23 +43,23 @@
    (:body (app {:uri "/page.html"})) => "I'm serving /page.html"))
 
 (fact
- "If you use paths without .html, it serves them as directories with
-  an index.html."
+ "If you use directory paths, it serves them as directories with an index.html."
 
  (let [app (serve-pages {"/page/" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
 
    (:body (app {:uri "/page/index.html"})) => "I'm serving /page/index.html"
-   (:body (app {:uri "/page/"})) => "I'm serving /page/index.html"
-   (app {:uri "/page"}) => {:status 301, :headers {"Location" "/page/"}}))
+   (:body (app {:uri "/page/"})) => "I'm serving /page/index.html"))
 
 (fact
- "Paths without .html or an ending slash is prohibited, because such URLs slow
-  your site down with needless redirects."
+ "If you use paths without .html and without a trailing slash it serves
+ the file and assumes the content type is text/html"
 
- ((serve-pages {"/ok.html" noop
-                "/ok/" noop
-                "/not-ok" noop})
-  {:uri "/"}) => (throws Exception "The following page paths must end in a slash: (\"/not-ok\")"))
+ (let [app (serve-pages {"/page" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+
+   (:body (app {:uri "/page"})) => "I'm serving /page"
+   (app {:uri "/page"}) => {:status 200
+                            :body "I'm serving /page"
+                            :headers {"Content-Type" "text/html"}}))
 
 (fact
  "It forces pages paths to be absolute paths."


### PR DESCRIPTION
@magnars assuming this is not something you would want given the explicit design, but thought I might as well confirm.

If it is something you'd be interested in I could clean this up (`statically-servable-uri?`, `project.clj`, etc) or could simply better explain what I'm trying to achieve. 

I'm pretty new to Clojure, if that isn't already apparent, though, so *buyer beware*. 