### PR TITLE
Slurp and serve UTF-8 encoded files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject stasis "2.2.2"
+(defproject stasis "2.2.3-SNAPSHOT"
   :description "A library of tools for creating static websites."
   :url "http://github.com/magnars/stasis"
   :license {:name "Eclipse Public License"

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -48,12 +48,12 @@
 (defn- serve-page [page uri]
   (-> {:status 200
        :body (if (map? page) (:contents page) page)}
-      (assoc-if (.endsWith uri ".html") :headers {"Content-Type" "text/html"})))
+      (assoc-if (.endsWith uri ".html") :headers {"Content-Type" "text/html; charset=utf-8"})))
 
 (def not-found
   {:status 404
    :body "<h1>Page not found</h1>"
-   :headers {"Content-Type" "text/html"}})
+   :headers {"Content-Type" "text/html; charset=utf-8"}})
 
 (defn- ensure-absolute-paths [paths]
   "Validates that the paths (the keys) of the pages are absolute paths,
@@ -167,14 +167,14 @@
 (defn- emacs-file? [^File file]
   (-> file get-path emacs-file-artefact?))
 
-(defn slurp-directory [dir regexp]
+(defn slurp-directory [dir regexp & opts]
   (let [dir (io/as-file dir)
         path-len (count (get-path dir))
         path-from-dir #(subs (get-path %) path-len)]
     (->> (file-seq dir)
          (remove emacs-file?)
          (filter #(re-find regexp (path-from-dir %)))
-         (map (juxt path-from-dir slurp))
+         (map (juxt path-from-dir #(apply slurp % opts)))
          (into {}))))
 
 (defn- chop-up-to [^String prefix ^String s]

--- a/test/stasis/core_test.clj
+++ b/test/stasis/core_test.clj
@@ -13,11 +13,11 @@
 
    (app {:uri "/page.html"}) => {:status 200
                                  :body "The page contents"
-                                 :headers {"Content-Type" "text/html"}}
+                                 :headers {"Content-Type" "text/html; charset=utf-8"}}
 
    (app {:uri "/missing.html"}) => {:status 404
                                     :body "<h1>Page not found</h1>"
-                                    :headers {"Content-Type" "text/html"}}))
+                                    :headers {"Content-Type" "text/html; charset=utf-8"}}))
 
 (fact
  "You can pass in a `get-pages` function too, if you need to determine
@@ -28,7 +28,7 @@
 
    (app {:uri "/page.html"}) => {:status 200
                                  :body "The page contents"
-                                 :headers {"Content-Type" "text/html"}}))
+                                 :headers {"Content-Type" "text/html; charset=utf-8"}}))
 
 (fact
  "A page can be a function too, which is passed its context with :uri in."
@@ -98,15 +98,15 @@
 
    (app {:uri "/"}) => {:status 200
                         :body "Hello"
-                        :headers {"Content-Type" "text/html"}}
+                        :headers {"Content-Type" "text/html; charset=utf-8"}}
 
    (app {:uri "/dependent.html"}) => {:status 200
                                       :body "Hi there"
-                                      :headers {"Content-Type" "text/html"}}
+                                      :headers {"Content-Type" "text/html; charset=utf-8"}}
 
    (app {:uri "/other-dependent.html"}) => {:status 200
                                             :body "Wazzup"
-                                            :headers {"Content-Type" "text/html"}}
+                                            :headers {"Content-Type" "text/html; charset=utf-8"}}
 
    (with-tmp-dir
      (export-pages pages tmp-dir)


### PR DESCRIPTION
Hi @magnars! First off, thank you for this incredibly useful library.

When I tried to serve files pulled using `slurp-directory`, I noticed that they did not correctly render UTF-8 encoded characters (instead rendering a `?`). 

This PR adds the ability to pass `opts` into `slurp-directory`, which are then passed to underlying calls to `slurp`. This can be used to pass an encoding like `(slurp-directory dir pattern :encoding "UTF-8")`.

It also adds the UTF-8 charset to the `Content-type` header so that files served through ring can be rendered correctly, and fixes tests to reflect this change.

Let me know if there's anything I'm missing and have a great day.