### PR TITLE
Pass opts from slurp-directory through to slurp

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ contents and transforms it to a list of Clojure data structures.
 It would serve all .html files in that folder, matching the URL
 structure to files on disk.
 
+Like [`slurp`](https://clojuredocs.org/clojure.core/slurp),
+`slurp-directory` can also receive optional arguments such as `:encoding`:
+
+```clj
+(slurp-directory "resources/articles/" #"\.md$" :encoding "UTF-8")
+```
+
 ### `slurp-resources`
 
 Just like `slurp-directory`, except it reads off the class path

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -167,14 +167,14 @@
 (defn- emacs-file? [^File file]
   (-> file get-path emacs-file-artefact?))
 
-(defn slurp-directory [dir regexp]
+(defn slurp-directory [dir regexp & opts]
   (let [dir (io/as-file dir)
         path-len (count (get-path dir))
         path-from-dir #(subs (get-path %) path-len)]
     (->> (file-seq dir)
          (remove emacs-file?)
          (filter #(re-find regexp (path-from-dir %)))
-         (map (juxt path-from-dir slurp))
+         (map (juxt path-from-dir #(apply slurp % opts)))
          (into {}))))
 
 (defn- chop-up-to [^String prefix ^String s]

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -181,13 +181,13 @@
   (subs s (+ (.indexOf s prefix)
              (count prefix))))
 
-(defn slurp-resources [dir regexp]
+(defn slurp-resources [dir regexp & opts]
   (->> (file-paths-on-class-path)
        (filter (fn [^String s] (.contains s (str dir "/"))))
        (filter #(re-find regexp %))
        (remove #(emacs-file-artefact? (chop-up-to dir %)))
        (map (juxt #(chop-up-to dir %)
-                  #(slurp (io/resource %))))
+                  #(apply slurp (io/resource %) opts)))
        (into {})))
 
 (defn- guard-against-collisions [pages]


### PR DESCRIPTION
This PR adds the ability to pass opts into slurp-directory, which are then passed to underlying calls to [`slurp`](https://clojuredocs.org/clojure.core/slurp).

Extracted from https://github.com/magnars/stasis/pull/15. 