### PR TITLE
Lepo.IO as an example site

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,12 @@ If you just want some code to look at, check these out:
   Parses markdown table syntax to create metadata and tags for its blog posts.
   Clever! Uses many of the same technologies listed above.
 
+- [lepo.io](https://lepo.io/) [(source)](https://github.com/Lepovirta/lepo)
+
+  Uses [Selmer](https://github.com/yogthos/Selmer) and
+  [Hiccup](https://github.com/weavejester/hiccup) for building the pages, and
+  [Optimus](https://github.com/magnars/optimus) for building assets.
+
 Got an open source site written in Stasis? Do let me know, and I'll
 add it here!
 


### PR DESCRIPTION
I've been using Stasis for a while for my personal homepage and now for a team site. This commit adds my team site, Lepo.IO, to the list of example sites. Let me know if there's more info you'd like me to add.