### PR TITLE
Remove troublesome outdated inflections dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [ring/ring-codec "1.0.0"]
-                 [narkisr/clansi "1.2.0"]
-                 [inflections "0.9.5" :exclusions [org.clojure/clojure commons-codec]]]
+                 [narkisr/clansi "1.2.0"]]
   :profiles {:dev {:dependencies [[midje "1.6.0"]
                                   [test-with-files "0.1.0"]]
                    :plugins [[lein-midje "3.1.3"]]

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -4,8 +4,7 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [ring.util.codec :refer [url-decode]]
-            [stasis.class-path :refer [file-paths-on-class-path]]
-            [inflections.core :refer [plural]])
+            [stasis.class-path :refer [file-paths-on-class-path]])
   (:import [java.io File]
            [java.util.regex Pattern]))
 
@@ -240,15 +239,12 @@
      :unchanged (set (remove is-changed? remaining))}))
 
 (defn- pluralize
-  "Add 's' to the end of a word to pluralize it. If it already ends in 's', add
-  'es'. If the optional count parameter is provided, the word will be pluralized
-  unless the count is 1, as in '1 apple, 2 apples'."
-  [word & [count]]
-  (if (= count 1) word (plural word)))
+  [count singular plural]
+  (if (= count 1) singular plural))
 
 (defn- print-heading [s entries color]
   (let [num (count entries)]
-    (println (ansi/style (format s num (pluralize "file" num)) color))))
+    (println (ansi/style (format s num (pluralize num "file" "files")) color))))
 
 (defn report-differences [old new]
   (let [{:keys [added removed changed unchanged]} (diff-maps old new)]


### PR DESCRIPTION
Stasis was using an old version of pluralize which was pulling in a ton of extra transitive dependencies including a dependency on an ancient version of nREPL which was causing problems for running an nrepl server.

I noticed pluralize was only being used in a very limited way in a private
function, so I just removed the dependency for a simpler function