### PR TITLE
update `ring/ring-codec`

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/magnars/stasis"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[ring/ring-codec "1.1.2"]
+  :dependencies [[ring/ring-codec "1.2.0"]
                  [narkisr/clansi "1.2.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [digest "1.4.9"]


### PR DESCRIPTION
Thanks so much for building stasis, I've really enjoyed using it!

I made this change locally so that I could use stasis from babashka, which makes for a really nice flow because of the minimal startup time. `ring-codec "1.2.0"` is compatible with babashka while `1.1.2` is not.