### PR TITLE
Spring cleaning: Port tests to clojure.test ++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	clojure -M:dev -m kaocha.runner
+
+autotest:
+	clojure -M:dev -m kaocha.runner --watch
+
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -587,17 +587,14 @@ certainly break it later.
 
 #### Running the tests
 
-`lein midje` will run all tests.
+`make test` will run all tests.
 
-`lein midje namespace.*` will run only tests beginning with "namespace.".
-
-`lein midje :autotest` will run all the tests indefinitely. It sets up a
-watcher on the code files. If they change, only the relevant tests will be
-run again.
+`make autotest` will run all the tests indefinitely. It sets up a watcher on the
+code files. If they change, only the relevant tests will be run again.
 
 ## License
 
-Copyright © 2014 Magnar Sveen
+Copyright © 2014-2023 Magnar Sveen
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,10 @@
+{:paths ["src"]
+ :deps {ring/ring-codec {:mvn/version "1.2.0"}
+        narkisr/clansi {:mvn/version "1.2.0"}}
+ :aliases
+ {:dev {:extra-paths ["dev-resources" "test"]
+        :extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}
+                     digest/digest {:mvn/version "1.4.9"}
+                     com.magnars/test-with-files {:mvn/version "2021-02-17"}
+                     lambdaisland/kaocha {:mvn/version "1.87.1366"}
+                     kaocha-noyoda/kaocha-noyoda {:mvn/version "2019-06-03"}}}}}

--- a/project.clj
+++ b/project.clj
@@ -7,8 +7,6 @@
                  [narkisr/clansi "1.2.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.1"]
                                   [digest "1.4.9"]
-                                  [midje "1.9.9"]
                                   [test-with-files "0.1.1"]]
-                   :plugins [[lein-ancient "0.6.15"]
-                             [lein-midje "3.2.1"]]
+                   :plugins [[lein-ancient "0.6.15"]]
                    :source-paths ["dev"]}})

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -52,9 +52,10 @@
    :body "<h1>Page not found</h1>"
    :headers {"Content-Type" "text/html"}})
 
-(defn- ensure-absolute-paths [paths]
+(defn- ensure-absolute-paths
   "Validates that the paths (the keys) of the pages are absolute paths,
    so that ring can serve them properly."
+  [paths]
   (let [errors (->> paths
                     (remove #(re-find #"^/" %)))]
     (when (seq errors)
@@ -62,9 +63,10 @@
                            (pr-str errors))
                       {:errors errors})))))
 
-(defn- ensure-statically-servable-paths [paths]
+(defn- ensure-statically-servable-paths
   "Validates that the paths (the keys) of the pages either end in a file extension or a slash,
    so that they can be served properly as static files."
+  [paths]
   (let [errors (->> paths
                     (remove statically-servable-uri?))]
     (when (seq errors)

--- a/src/stasis/core.clj
+++ b/src/stasis/core.clj
@@ -159,7 +159,7 @@
       (export-page uri pageish target-dir options))))
 
 (defn- delete-file-recursively [f]
-  (if (.isDirectory f)
+  (when (.isDirectory f)
     (doseq [child (.listFiles f)]
       (delete-file-recursively child)))
   (io/delete-file f))
@@ -169,7 +169,7 @@
     (if (.isDirectory f)
       (doseq [child (.listFiles f)]
         (delete-file-recursively child))
-      (if (.exists f)
+      (when (.exists f)
         (throw (Exception. (str (get-path f) " is not a directory.")))))))
 
 (defn- just-the-filename [^String path]

--- a/test/stasis/core_test.clj
+++ b/test/stasis/core_test.clj
@@ -1,292 +1,283 @@
 (ns stasis.core-test
-  (:require [stasis.core :refer :all]
-            [midje.sweet :refer :all]
-            [clojure.java.io :as io]
-            digest
-            [test-with-files.core :refer [with-files with-tmp-dir tmp-dir public-dir]]))
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [digest]
+            [stasis.core :as sut]
+            [test-with-files.core :refer [public-dir tmp-dir with-files with-tmp-dir]]))
 
 (defn noop [_] nil)
 
-(fact
- "Stasis creates a Ring handler to serve your pages."
+(deftest serve-pages-test
+  (testing "Stasis creates a Ring handler to serve your pages."
+    (is (= (let [app (sut/serve-pages {"/page.html" "The page contents"})]
+             (app {:uri "/page.html"}))
+           {:status 200
+            :body "The page contents"
+            :headers {"Content-Type" "text/html"}})))
 
- (let [app (serve-pages {"/page.html" "The page contents"})]
+  (testing "Serves 404 for missing page"
+    (is (= (let [app (sut/serve-pages {"/page.html" "The page contents"})]
+             (app {:uri "/missing.html"}))
+           {:status 404
+            :body "<h1>Page not found</h1>"
+            :headers {"Content-Type" "text/html"}})))
 
-   (app {:uri "/page.html"}) => {:status 200
-                                 :body "The page contents"
-                                 :headers {"Content-Type" "text/html"}}
+  (testing "You can pass in a `get-pages` function too, if you need to determine
+            the set of pages dynamically and want them to be properly live."
+    (is (= (let [get-pages (fn [] {"/page.html" "The page contents"})
+                 app (sut/serve-pages get-pages)]
 
-   (app {:uri "/missing.html"}) => {:status 404
-                                    :body "<h1>Page not found</h1>"
-                                    :headers {"Content-Type" "text/html"}}))
+             (app {:uri "/page.html"}))
+           {:status 200
+            :body "The page contents"
+            :headers {"Content-Type" "text/html"}})))
 
-(fact
- "You can pass in a `get-pages` function too, if you need to determine
-  the set of pages dynamically and want them to be properly live."
+  (testing "A page can be a function too, which is passed its context with :uri in."
+    (is (= (let [app (sut/serve-pages {"/page.html" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+             (:body (app {:uri "/page.html"})))
+           "I'm serving /page.html")))
 
- (let [get-pages (fn [] {"/page.html" "The page contents"})
-       app (serve-pages get-pages)]
+  (testing "When the :stasis/ignore-nil-pages? value in the options map is false,
+            requests for pages with nil values should throw an exception"
+    (let [app1 (sut/serve-pages {"/page.html" nil})]
+      (is (thrown-with-msg? Exception #"Page value is unexpectedly nil" (app1 {:uri "/page.html"}))))
+    (let [app2 (sut/serve-pages {"/page.html" noop})]
+      (is (thrown-with-msg? Exception #"Page value is unexpectedly nil" (app2 {:uri "/page.html"})))))
 
-   (app {:uri "/page.html"}) => {:status 200
-                                 :body "The page contents"
-                                 :headers {"Content-Type" "text/html"}}))
+  (testing "When the :stasis/ignore-nil-pages? value in the options map is true,
+            requests for pages with nil values will be ignored and the response
+            status will be 404"
+    (let [app1 (sut/serve-pages {"/page.html" nil} {:stasis/ignore-nil-pages? true})]
+      (is (= (app1 {:uri "/page.html"})
+             {:status 404
+              :body "<h1>Page not found</h1>"
+              :headers {"Content-Type" "text/html"}})))
+    (let [app2 (sut/serve-pages {"/page.html" noop} {:stasis/ignore-nil-pages? true})]
+      (is (= (app2 {:uri "/page.html"})
+             {:status 404
+              :body "<h1>Page not found</h1>"
+              :headers {"Content-Type" "text/html"}}))))
 
-(fact
- "A page can be a function too, which is passed its context with :uri in."
+  (testing "If you use paths without .html, it serves them as directories with
+            an index.html."
+    (let [app (sut/serve-pages {"/page/" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+      (is (= (:body (app {:uri "/page/index.html"})) "I'm serving /page/index.html"))
+      (is (= (:body (app {:uri "/page/"})) "I'm serving /page/index.html"))
+      (is (= (app {:uri "/page"}) {:status 301, :headers {"Location" "/page/"}}))))
 
- (let [app (serve-pages {"/page.html" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+  (testing "Paths without .html or an ending slash is prohibited, because such URLs
+            slow your site down with needless redirects."
+    (is (thrown-with-msg? Exception #"The following page paths must end in a slash: \(\"/not-ok\"\)"
+                          ((sut/serve-pages {"/ok.html" noop
+                                             "/ok/" noop
+                                             "/not-ok" noop})
+                           {:uri "/"}))))
 
-   (:body (app {:uri "/page.html"})) => "I'm serving /page.html"))
+  (testing "It forces pages paths to be absolute paths."
+    (is (thrown-with-msg?
+         Exception #"The following pages must have absolute paths: \(\"foo.html\"\)"
+         ((sut/serve-pages {"foo.html" "bar"}) {:uri "/"})))
+    (is (thrown-with-msg?
+         Exception #"The following pages must have absolute paths: \(\"foo.html\"\)"
+         (sut/export-pages {"foo.html" "bar"} nil))))
 
-(fact
- "When the :stasis/ignore-nil-pages? value in the options map is false, requests
- for pages with nil values should throw an exception"
- (let [app1 (serve-pages {"/page.html" nil})
-       app2 (serve-pages {"/page.html" noop})]
+  (testing "If you use paths with strange characters, like { and }, it transparently
+            decodes incoming URLs"
+    (is (= (let [app (sut/serve-pages {"/page/{thing-a-majig}/" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+             (:body (app {:uri "/page/%7Bthing-a-majig%7D/"})))
+           "I'm serving /page/{thing-a-majig}/index.html")))
 
-   (app1 {:uri "/page.html"}) => (throws Exception "Page value is unexpectedly nil")
+  (testing "You can pass along config options to serve-pages that will be
+            included on each request."
+    (is (= (let [app (sut/serve-pages {"/page/" (fn [ctx] (str "Config: " (:config ctx)))}
+                                      {:config "Passed!"})]
+             (:body (app {:uri "/page/"})))
+           "Config: Passed!")))
 
-   (app2 {:uri "/page.html"}) => (throws Exception "Page value is unexpectedly nil")))
+  (testing "You can serve other types of assets too."
+    (let [pages {"/page-details.js"
+                 (fn [ctx] (str "alert('" (:uri ctx) "');"))
 
-(fact
- "When the :stasis/ignore-nil-pages? value in the options map is true, requests
- for pages with nil values will be ignored and the response status will be 404"
- (let [app1 (serve-pages {"/page.html" nil} {:stasis/ignore-nil-pages? true})
-       app2 (serve-pages {"/page.html" noop} {:stasis/ignore-nil-pages? true})]
+                 ;;See <https://en.wikipedia.org/wiki/Standard_test_image>
+                 "/jellybeans.png"
+                 (fn [_] (io/file "dev-resources" "4.1.07.png"))}
+          app (sut/serve-pages pages)]
 
-   (app1 {:uri "/page.html"}) => {:status 404
-                                  :body "<h1>Page not found</h1>"
-                                  :headers {"Content-Type" "text/html"}}
+      (is (= (app {:uri "/page-details.js"})
+             {:status 200
+              :body "alert('/page-details.js');"}))
 
-   (app2 {:uri "/page.html"}) => {:status 404
-                                  :body "<h1>Page not found</h1>"
-                                  :headers {"Content-Type" "text/html"}}))
+      (is (= (-> (app {:uri "/jellybeans.png"}) :body .getName) "4.1.07.png"))
 
-(fact
- "If you use paths without .html, it serves them as directories with
-  an index.html."
+      (is (= (with-tmp-dir
+               (sut/export-pages pages tmp-dir)
 
- (let [app (serve-pages {"/page/" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+               ;; Calculated using:
+               ;; $ md5sum dev-resources/4.1.07.png
+               ;; d84246a8ba02c2e3ee87b07813596d68  dev-resources/4.1.07.png
+               (->> "jellybeans.png" (io/file tmp-dir) digest/md5))
+             "d84246a8ba02c2e3ee87b07813596d68"))))
 
-   (:body (app {:uri "/page/index.html"})) => "I'm serving /page/index.html"
-   (:body (app {:uri "/page/"})) => "I'm serving /page/index.html"
-   (app {:uri "/page"}) => {:status 301, :headers {"Location" "/page/"}}))
+  (testing "When creating a page, you might realize that other dependent pages are
+            needed as well. Stasis helps you out by allowing a page to be a map of
+            {:contents, :dependent-pages}."
+    (let [pages {"/" (fn [_] {:contents "Hello"
+                              :dependent-pages {"/dependent.html" "Hi there"}})
+                 "/other.html" {:contents "Yo"
+                                :dependent-pages {"/other-dependent.html" "Wazzup"}}}
+          app (sut/serve-pages pages)]
 
-(fact
- "Paths without .html or an ending slash is prohibited, because such URLs slow
-  your site down with needless redirects."
+      (is (= (app {:uri "/"})
+             {:status 200
+              :body "Hello"
+              :headers {"Content-Type" "text/html"}}))
 
- ((serve-pages {"/ok.html" noop
-                "/ok/" noop
-                "/not-ok" noop})
-  {:uri "/"}) => (throws Exception "The following page paths must end in a slash: (\"/not-ok\")"))
+      (is (= (app {:uri "/dependent.html"})
+             {:status 200
+              :body "Hi there"
+              :headers {"Content-Type" "text/html"}}))
 
-(fact
- "It forces pages paths to be absolute paths."
- ((serve-pages {"foo.html" "bar"}) {:uri "/"}) => (throws Exception "The following pages must have absolute paths: (\"foo.html\")")
- (export-pages {"foo.html" "bar"} nil) => (throws Exception "The following pages must have absolute paths: (\"foo.html\")"))
+      (is (= (app {:uri "/other-dependent.html"})
+             {:status 200
+              :body "Wazzup"
+              :headers {"Content-Type" "text/html"}}))
 
-(fact
- "If you use paths with strange characters, like { and }, it transparently
-  decodes incoming URLs"
+      (with-tmp-dir
+        (sut/export-pages pages tmp-dir)
 
- (let [app (serve-pages {"/page/{thing-a-majig}/" (fn [ctx] (str "I'm serving " (:uri ctx)))})]
+        (is (= (slurp (str tmp-dir "/index.html")) "Hello"))
+        (is (= (slurp (str tmp-dir "/dependent.html")) "Hi there"))
+        (is (= (slurp (str tmp-dir "/other-dependent.html")) "Wazzup")))))
 
-   (:body (app {:uri "/page/%7Bthing-a-majig%7D/"})) => "I'm serving /page/{thing-a-majig}/index.html"))
+  (testing "Stasis exports pages to your directory of choice."
+    (is (= (with-tmp-dir
+             (sut/export-pages {"/page/index.html" "The contents"}
+                               tmp-dir)
+             (slurp (str tmp-dir "/page/index.html")))
+           "The contents")))
 
-(fact
- "You can pass along config options to serve-pages that will be
-  included on each request."
+  (testing "Stasis adds the :uri to the context for exported pages."
+    (is (= (with-tmp-dir
+             (sut/export-pages {"/page/" (fn [ctx] (str "I'm serving " (:uri ctx)))}
+                               tmp-dir)
+             (slurp (str tmp-dir "/page/index.html")))
+           "I'm serving /page/index.html")))
 
- (let [app (serve-pages {"/page/" (fn [ctx] (str "Config: " (:config ctx)))}
-                        {:config "Passed!"})]
+  (testing "Stasis will throw an exception when exporting a page with a nil value"
+    (is (thrown-with-msg?
+         Exception #"Page value is unexpectedly nil"
+         (with-tmp-dir (sut/export-pages {"/page/" nil} tmp-dir))))
 
-   (:body (app {:uri "/page/"})) => "Config: Passed!"))
+    (is (thrown-with-msg?
+         Exception #"Page value is unexpectedly nil"
+         (with-tmp-dir (sut/export-pages {"/page/" noop} tmp-dir)))))
 
-(fact
- "You can serve other types of assets too."
+  (testing "Stasis will not export a page with a nil value when :stasis/ignore-nil-pages? is true in the options map"
+    (with-tmp-dir
+      (is (nil? (sut/export-pages {"/page/" nil} tmp-dir {:stasis/ignore-nil-pages? true})))
+      (is (not (.exists (io/file tmp-dir "page/index.html")))))
 
- (let [pages {"/page-details.js"
-              (fn [ctx] (str "alert('" (:uri ctx) "');"))
+    (with-tmp-dir
+      (is (nil? (sut/export-pages {"/page/" noop} tmp-dir {:stasis/ignore-nil-pages? true})))
+      (is (not (.exists (io/file tmp-dir "page/index.html"))))))
 
-              ;;See <https://en.wikipedia.org/wiki/Standard_test_image>
-              "/jellybeans.png"
-              (fn [_] (io/file "dev-resources" "4.1.07.png"))}
-       app (serve-pages pages)]
+  (testing "You can add more information to the context if you want. Like
+            configuration options, or optimus assets."
+    (is (= (with-tmp-dir
+             (sut/export-pages {"/page/" (fn [ctx] (str "I got " (:conf ctx)))}
+                               tmp-dir {:conf "served"})
+             (slurp (str tmp-dir "/page/index.html")))
+           "I got served")))
 
-   (app {:uri "/page-details.js"}) => {:status 200
-                                       :body "alert('/page-details.js');"}
+  (testing "You can't accidentaly empty a file with empty-directory!"
+    (with-tmp-dir
+      (sut/export-pages {"/folder/page.html" (fn [ctx] "Contents")} tmp-dir {})
+      (is (thrown-with-msg?
+           Exception (re-pattern (str tmp-dir "/folder/page.html is not a directory."))
+           (sut/empty-directory! (str tmp-dir "/folder/page.html"))))))
 
-   (-> (app {:uri "/jellybeans.png"}) :body .getName) => "4.1.07.png"
+  (testing "But it's really easy emptying an entire folder of files. Be careful."
+    (with-tmp-dir
+      (sut/export-pages {"/folder/page.html" (fn [ctx] "Contents")} tmp-dir {})
+      (sut/empty-directory! (str tmp-dir "/folder"))
 
-   (with-tmp-dir
-     (export-pages pages tmp-dir)
+      (is (not (.exists (io/as-file (str tmp-dir "/folder/page.html")))))
+      (is (.exists (io/as-file (str tmp-dir "/folder"))))))
 
-     ;; Calculated using:
-     ;; $ md5sum dev-resources/4.1.07.png
-     ;; d84246a8ba02c2e3ee87b07813596d68  dev-resources/4.1.07.png
-     (->> "jellybeans.png" (io/file tmp-dir) digest/md5)
-     =>
-     "d84246a8ba02c2e3ee87b07813596d68")))
+  (testing "Emptying non-existing folders is a-o-k. It's, like, extra empty, dude."
+    (is (nil? (with-tmp-dir
+                (sut/export-pages {"/folder/page.html" (fn [ctx] "Contents")} tmp-dir {})
+                (sut/empty-directory! (str tmp-dir "/missing"))))))
 
-(fact
- "When creating a page, you might realize that other dependent pages are needed as
-  well. Stasis helps you out by allowing a page to be a map of {:contents, :dependent-pages}."
-
- (let [pages {"/" (fn [_] {:contents "Hello"
-                           :dependent-pages {"/dependent.html" "Hi there"}})
-              "/other.html" {:contents "Yo"
-                             :dependent-pages {"/other-dependent.html" "Wazzup"}}}
-       app (serve-pages pages)]
-
-   (app {:uri "/"}) => {:status 200
-                        :body "Hello"
-                        :headers {"Content-Type" "text/html"}}
-
-   (app {:uri "/dependent.html"}) => {:status 200
-                                      :body "Hi there"
-                                      :headers {"Content-Type" "text/html"}}
-
-   (app {:uri "/other-dependent.html"}) => {:status 200
-                                            :body "Wazzup"
-                                            :headers {"Content-Type" "text/html"}}
-
-   (with-tmp-dir
-     (export-pages pages tmp-dir)
-
-     (slurp (str tmp-dir "/index.html")) => "Hello"
-     (slurp (str tmp-dir "/dependent.html")) => "Hi there"
-     (slurp (str tmp-dir "/other-dependent.html")) => "Wazzup")))
-
-(fact
- "Stasis exports pages to your directory of choice."
-
- (with-tmp-dir
-   (export-pages {"/page/index.html" "The contents"}
-                 tmp-dir)
-   (slurp (str tmp-dir "/page/index.html")) => "The contents"))
-
-(fact
- "Stasis adds the :uri to the context for exported pages."
-
- (with-tmp-dir
-   (export-pages {"/page/" (fn [ctx] (str "I'm serving " (:uri ctx)))}
-                 tmp-dir)
-   (slurp (str tmp-dir "/page/index.html")) => "I'm serving /page/index.html"))
-
-(fact
- "Stasis will throw an exception when exporting a page with a nil value"
-
- (with-tmp-dir
-   (export-pages {"/page/" nil} tmp-dir) => (throws Exception "Page value is unexpectedly nil"))
-
- (with-tmp-dir
-   (export-pages {"/page/" noop} tmp-dir) => (throws Exception "Page value is unexpectedly nil")))
-
-(fact
- "Stasis will not export a page with a nil value when :stasis/ignore-nil-pages? is true in the options map"
-
- (with-tmp-dir
-   (export-pages {"/page/" nil} tmp-dir {:stasis/ignore-nil-pages? true}) => nil
-   (.exists (io/file tmp-dir "page/index.html")) => false)
-
- (with-tmp-dir
-   (export-pages {"/page/" noop} tmp-dir {:stasis/ignore-nil-pages? true}) => nil
-   (.exists (io/file tmp-dir "page/index.html")) => false))
-
-(fact
- "You can add more information to the context if you want. Like
-  configuration options, or optimus assets."
-
- (with-tmp-dir
-   (export-pages {"/page/" (fn [ctx] (str "I got " (:conf ctx)))}
-                 tmp-dir {:conf "served"})
-   (slurp (str tmp-dir "/page/index.html")) => "I got served"))
-
-(with-tmp-dir
-  (export-pages {"/folder/page.html" (fn [ctx] "Contents")} tmp-dir {})
-
-  (fact
-   "You can't accidentaly empty a file with empty-directory!"
-
-   (empty-directory! (str tmp-dir "/folder/page.html"))
-   => (throws Exception (str tmp-dir "/folder/page.html is not a directory.")))
-
-  (fact
-   "But it's really easy emptying an entire folder of files. Be careful."
-
-   (empty-directory! (str tmp-dir "/folder"))
-
-   (io/as-file (str tmp-dir "/folder/page.html")) => #(not (.exists %))
-   (io/as-file (str tmp-dir "/folder")) => #(.exists %))
-
-  (fact
-   "Emptying non-existing folders is a-o-k. It's, like, extra empty, dude."
-
-   (empty-directory! (str tmp-dir "/missing"))))
-
-(with-files [["/texts/banana.txt" "Banana"]
-             ["/texts/apple.txt" "Apple"]
-             ["/texts/fruit.txt" "Fruit"]
-             ["/texts/irrelevant.md" "Left out"]
-             ["/texts/.#emacs.txt" "Temp files are cool beans"]]
-
-  (fact (slurp-directory (str tmp-dir "/texts") #"\.txt$")
-        => {"/banana.txt" "Banana"
+  (testing "Slurps text files"
+    (is (= (with-files [["/texts/banana.txt" "Banana"]
+                        ["/texts/apple.txt" "Apple"]
+                        ["/texts/fruit.txt" "Fruit"]
+                        ["/texts/irrelevant.md" "Left out"]
+                        ["/texts/.#emacs.txt" "Temp files are cool beans"]]
+             (sut/slurp-directory (str tmp-dir "/texts") #"\.txt$"))
+           {"/banana.txt" "Banana"
             "/apple.txt" "Apple"
-            "/fruit.txt" "Fruit"})
+            "/fruit.txt" "Fruit"})))
 
-  (fact (slurp-resources (str public-dir "/texts") #"\.txt$")
-        => {"/banana.txt" "Banana"
+  (testing "Slurps public dir"
+    (is (= (with-files [["/texts/banana.txt" "Banana"]
+                        ["/texts/apple.txt" "Apple"]
+                        ["/texts/fruit.txt" "Fruit"]
+                        ["/texts/irrelevant.md" "Left out"]
+                        ["/texts/.#emacs.txt" "Temp files are cool beans"]]
+
+
+             (sut/slurp-resources (str public-dir "/texts") #"\.txt$"))
+           {"/banana.txt" "Banana"
             "/apple.txt" "Apple"
-            "/fruit.txt" "Fruit"}))
+            "/fruit.txt" "Fruit"})))
 
-(with-files [["/texts/fruit/banana.txt" "Banana"]
-             ["/texts/fruit/apple.txt" "Apple"]
-             ["/texts/vegetables/cucumber.txt" "Cucumber"]]
-
-  (fact (slurp-directory (str tmp-dir "/texts") #"\.txt$")
-        => {"/fruit/banana.txt" "Banana"
+  (testing "Slurps directory"
+    (is (= (with-files [["/texts/fruit/banana.txt" "Banana"]
+                        ["/texts/fruit/apple.txt" "Apple"]
+                        ["/texts/vegetables/cucumber.txt" "Cucumber"]]
+             (sut/slurp-directory (str tmp-dir "/texts") #"\.txt$"))
+           {"/fruit/banana.txt" "Banana"
             "/fruit/apple.txt" "Apple"
-            "/vegetables/cucumber.txt" "Cucumber"}))
+            "/vegetables/cucumber.txt" "Cucumber"})))
 
-(fact "It merges pages from several sources"
-      (merge-page-sources {:general-pages {"/people.html" "People"}
-                           :article-pages {"/folks.html" "Folks"}})
-      => {"/people.html" "People"
-          "/folks.html" "Folks"})
+  (testing "It merges pages from several sources"
+    (is (= (sut/merge-page-sources {:general-pages {"/people.html" "People"}
+                                    :article-pages {"/folks.html" "Folks"}})
+           {"/people.html" "People"
+            "/folks.html" "Folks"})))
 
-(fact "Colliding urls are not tolerated when merging."
+  (testing "Colliding urls are not tolerated when merging."
+    (is (thrown-with-msg?
+         Exception #"URL conflicts between :article-pages and :general-pages: #\{\"/people.html\"\}"
+         (sut/merge-page-sources {:general-pages {"/people.html" ""
+                                                  "/about.html" ""}
+                                  :article-pages {"/people.html" ""
+                                                  "/folks.html" ""}})))
 
-      (merge-page-sources {:general-pages {"/people.html" ""
-                                           "/about.html" ""}
-                           :article-pages {"/people.html" ""
-                                           "/folks.html" ""}})
-      => (throws Exception "URL conflicts between :article-pages and :general-pages: #{\"/people.html\"}")
+    (is (thrown-with-msg?
+         Exception #"URL conflicts between :article-pages and :person-pages: #\{\"/magnars.html\" \"/finnjoh.html\"\}"
+         (sut/merge-page-sources {:person-pages {"/magnars.html" ""
+                                                 "/finnjoh.html" ""}
+                                  :article-pages {"/magnars.html" ""
+                                                  "/finnjoh.html" ""}
+                                  :general-pages {"/people.html" ""}}))))
 
-      (merge-page-sources {:person-pages {"/magnars.html" ""
-                                          "/finnjoh.html" ""}
-                           :article-pages {"/magnars.html" ""
-                                           "/finnjoh.html" ""}
-                           :general-pages {"/people.html" ""}})
-      => (throws Exception "URL conflicts between :article-pages and :person-pages: #{\"/magnars.html\" \"/finnjoh.html\"}"))
+  (testing "It detects clashes for non-normalized URLs too."
+    (is (thrown-with-msg?
+         Exception #"URL conflicts between :article-pages and :general-pages: #\{\"/index.html\"\}"
+         (sut/merge-page-sources {:general-pages {"/" ""}
+                                  :article-pages {"/index.html" ""}}))))
 
-(fact "It detects clashes for non-normalized URLs too."
-
-      (merge-page-sources {:general-pages {"/" ""}
-                           :article-pages {"/index.html" ""}})
-      => (throws Exception "URL conflicts between :article-pages and :general-pages: #{\"/index.html\"}"))
-
-(fact "It finds differences between maps (used by report-differences)."
-
-      (diff-maps {"/texts/fruit/banana.txt" "Banana"
-                  "/texts/fruit/apple.txt" "Apple"
-                  "/texts/vegetables/cucumber.txt" "Cucumber"}
-                 {"/texts/fruit/banana.txt" "Banana"
-                  "/texts/fruit/apple.txt" "Apple!"
-                  "/texts/vegetables/tomato.txt" "Tomato"})
-
-      => {:removed #{"/texts/vegetables/cucumber.txt"}
-          :added #{"/texts/vegetables/tomato.txt"}
-          :changed #{"/texts/fruit/apple.txt"}
-          :unchanged #{"/texts/fruit/banana.txt"}})
+  (testing "It finds differences between maps (used by report-differences)."
+    (is (= (sut/diff-maps {"/texts/fruit/banana.txt" "Banana"
+                           "/texts/fruit/apple.txt" "Apple"
+                           "/texts/vegetables/cucumber.txt" "Cucumber"}
+                          {"/texts/fruit/banana.txt" "Banana"
+                           "/texts/fruit/apple.txt" "Apple!"
+                           "/texts/vegetables/tomato.txt" "Tomato"})
+           {:removed #{"/texts/vegetables/cucumber.txt"}
+            :added #{"/texts/vegetables/tomato.txt"}
+            :changed #{"/texts/fruit/apple.txt"}
+            :unchanged #{"/texts/fruit/banana.txt"}}))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,0 +1,2 @@
+#kaocha/v1
+{:plugins [:noyoda.plugin/swap-actual-and-expected]}


### PR DESCRIPTION
It's 2023 and us lisp people want s-expressions, even in the tests. So this pull request fixes a few minor aesthetic issues in the code, adds deps.edn and kaocha, and replaces midje tests with clojure.test.

I didn't remove the leiningen file, cause I suspected you might use it to release stuff? I can help adding some release tooling for deps.edn if interested as well.